### PR TITLE
PelletierConstructionGroup.github.io _6_50_ add-contact-page-map-contact.html

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -212,7 +212,7 @@
              data-testid = "section-block">
             <div class = "overlay-container">
                 <div class = "section__content">
-                    <div class = "map map--s map-placeholder">
+                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2685.7110808593616!2d-122.34478752321982!3d47.69003068221194!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x43e37fc0e8bfa93b%3A0x7d396a5758dc84b2!2sPelletier%20Construction%20Group!5e0!3m2!1sen!2sus!4v1715303808520!5m2!1sen!2sus" width=100% height="200" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                         <div class = "map-placeholder__attribution">Map Data @ Google 2023</div>
                         <div role = "dialog"
                              class = "privacy-cookies-dialog privacy-cookies-dialog-map">


### PR DESCRIPTION
Resolves #50 
This PR added a Google Map for Contact Page: contact.html. I used iframe src code and inserted into our map placeholder. However, the cookies enabling button is still there and had been pushed below the map, I'm not sure if I have to make changes to it but it's there.
![image](https://github.com/PelletierConstructionGroup/PelletierConstructionGroup.github.io/assets/78373874/573a73ea-7b13-4751-a00d-d5f979f68430)

