### PR TITLE
PelletierConstructionGroup-6-54-01-restore_about_page_style

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,7 +34,7 @@
     />
     <link href="/" rel="dns-prefetch" />
     <link
-      href="\index.css"
+      href="index.css"
       rel="stylesheet"
     />
     <link href="https://pelletierconstructiongroup.com/about" rel="canonical" />
@@ -65,22 +65,22 @@
     <meta content="17" name="next-head-count" />
     <link
       as="style"
-      href="\index.css"
+      href="index.css"
       rel="preload"
     />
     <link
       data-n-g=""
-      href="\index.css"
+      href="index.css"
       rel="stylesheet"
     />
     <link
       as="style"
-      href="\global.css"
+      href="project.css"
       rel="preload"
     />
     <link
       data-n-p=""
-      href="\global.css"
+      href="project.css"
       rel="stylesheet"
     />
     <noscript data-n-css=""></noscript>


### PR DESCRIPTION
related to #54
Restore about page style for Houzz link removal. 

![image](https://github.com/PelletierConstructionGroup/PelletierConstructionGroup.github.io/assets/137982978/0472a147-8eca-40ee-8876-97ce12baec68)
