### PR TITLE
PelletierConstructionGroup_6_73_remove-contact-map-cookies

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -210,14 +210,14 @@
                 <div class = "section__content">
                     <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2685.7110808593616!2d-122.34478752321982!3d47.69003068221194!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x43e37fc0e8bfa93b%3A0x7d396a5758dc84b2!2sPelletier%20Construction%20Group!5e0!3m2!1sen!2sus!4v1715303808520!5m2!1sen!2sus" width=100% height="200" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                         <div class = "map-placeholder__attribution">Map Data @ Google 2023</div>
-                        <div role = "dialog"
+                        <!-- <div role = "dialog"
                              class = "privacy-cookies-dialog privacy-cookies-dialog-map">
                             <h1 class = "privacy-cookies-heading">This Content Requires Cookies</h1>
                             <button style = "margin-top:8px"
                                     class = "unstyled-button privacy-cookies-button privacy-cookies-button__primary">
                                 Enable Functionality Cookies
                             </button>
-                        </div>
+                        </div> -->
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR comments out the code for the cookies modal and removes it from under the maps section on the contact page.